### PR TITLE
Add KDE 6.10 runtime

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,10 @@ jobs:
             packages: org.kde.Platform//6.9 org.kde.Sdk//6.9
             remote: flathub
 
+          - name: kde-6.10
+            packages: org.kde.Platform//6.10 org.kde.Sdk//6.10
+            remote: flathub
+
     services:
       registry:
         image: registry:latest

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ The following images are available:
 | KDE             | 5.15-24.08 | `kde-5.15-24.08`    | `image: ghcr.io/flathub-infra/flatpak-github-actions:kde-5.15-24.08`    |
 | KDE             | 6.8        | `kde-6.8`           | `image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.8`           |
 | KDE             | 6.9        | `kde-6.9`           | `image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9`           |
+| KDE             | 6.10        | `kde-6.10`           | `image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10`           |


### PR DESCRIPTION
Runtime now available https://discuss.kde.org/t/flatpak-org-kde-sdk-6-10-runtime-is-now-available/41158.